### PR TITLE
Added a command that allow starting the container after it has been stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ docker run -d \
 Where:
   - `$HOME/ps3games`: This location contains files from your host that need to be accessible by the application.
 
-
+If the container has been stopped for some reasons, you can continue it by running the following command:
+```
+docker start ps3netsrv
+```
 ## Usage
 
 ```


### PR DESCRIPTION
This command should allow restarting the container without the need of removing container or renaming it to something else:
```
docker start ps3netsrv
```