### PR TITLE
The environment block expects a map, not an enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ services:
   ps3netsrv:
     image: shawly/ps3netsrv
     environment:
-      - TZ: Europe/Berlin
-      - USER_ID: 38008
-      - GROUP_ID: 38008
+      TZ: Europe/Berlin
+      USER_ID: 38008
+      GROUP_ID: 38008
     ports:
       - "38008:38008"
     volumes:


### PR DESCRIPTION
The docker-compose in the readme doesn't work, I've fixed it